### PR TITLE
Filter for string to ascii hex

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -427,6 +427,11 @@ module Liquid
       end
     end
 
+    #Convert a string to ascii (in hex)
+    def string_to_ascii(input)
+      input.split('').map(&:ord).map{ |n| n.to_s(16) }
+    end
+
     private
 
     def raise_property_error(property)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -683,6 +683,10 @@ class StandardFiltersTest < Minitest::Test
     assert_equal "bar", @filters.default({}, "bar")
   end
 
+  def test_string_to_ascii
+    assert_equal ["54", "65", "73", "74", "69", "6e", "67"], @filters.string_to_ascii("Testing")
+  end
+
   def test_cannot_access_private_methods
     assert_template_result('a', "{{ 'a' | to_number }}")
   end


### PR DESCRIPTION
Created new filter to convert string to ascii, then hex.
The name of the filter is string_to_ascii.