### PR TITLE
Use two different filters

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -427,9 +427,14 @@ module Liquid
       end
     end
 
-    #Convert a string to ascii (in hex)
-    def string_to_ascii(input)
-      input.split('').map(&:ord).map{ |n| n.to_s(16) }
+    #Convert a string to ascii
+    def to_ascii(input)
+      input.chars.map{ |c| c.ord }
+    end
+
+    #Convert to hexadecimal
+    def to_hex(input)
+      input.map{ |c| c.to_s(16) }
     end
 
     private

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -683,8 +683,12 @@ class StandardFiltersTest < Minitest::Test
     assert_equal "bar", @filters.default({}, "bar")
   end
 
-  def test_string_to_ascii
-    assert_equal ["54", "65", "73", "74", "69", "6e", "67"], @filters.string_to_ascii("Testing")
+  def test_to_ascii
+    assert_equal [84, 101, 115, 116, 105, 110, 103], @filters.to_ascii("Testing")
+  end
+
+  def test_to_hex
+    assert_equal ["54", "65", "73", "74", "69", "6e", "67"], @filters.to_hex([84, 101, 115, 116, 105, 110, 103])
   end
 
   def test_cannot_access_private_methods


### PR DESCRIPTION
Change `string_to_ascii` to two different filters, `to_ascii` and `to_hex`