### PR TITLE
Lambda Expression Filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -434,7 +434,16 @@ module Liquid
 
     #Convert to hexadecimal
     def to_hex(input)
-      input.map{ |c| c.to_s(16) }
+      if input.class == String
+        input.to_i.to_s(16)
+      elsif input.class == Array 
+        if input.all? { |x| x.is_a? String } 
+          input = input.map{ |c| c.to_i }
+        end
+        input.map{ |c| c.to_s(16) }
+      end
+      
+      
     end
 
     def lambda_expr(input, *x, expr)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -434,16 +434,7 @@ module Liquid
 
     #Convert to hexadecimal
     def to_hex(input)
-      if input.class == String
-        input.to_i.to_s(16)
-      elsif input.class == Array 
-        if input.all? { |x| x.is_a? String } 
-          input = input.map{ |c| c.to_i }
-        end
-        input.map{ |c| c.to_s(16) }
-      end
-      
-      
+      input.map{ |c| c.to_s(16) }
     end
 
     def lambda_expr(input, *x, expr)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -447,13 +447,13 @@ module Liquid
     
       counter = 0
       while(counter != inputhash.size())
-        if(expr.include? inputhash.keys[counter].tr(':',''))
+        if(expr.include? inputhash.keys[counter])
           isnum = /^\d+$/.match(inputhash.values[counter])
           if(isnum.to_s.length == inputhash.values[counter].length)
-            expr = expr.gsub(expr[inputhash.keys[counter].tr(':','')], inputhash.values[counter].to_s)
+            expr = expr.gsub(expr[inputhash.keys[counter]], inputhash.values[counter].to_s)
           else
             rep = inputhash.values[counter]
-            expr = expr.gsub(expr[inputhash.keys[counter].tr(':','')], %('#{rep}') )
+            expr = expr.gsub(expr[inputhash.keys[counter]], %('#{rep}') )
           end
         end
         counter = counter + 1

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -442,7 +442,7 @@ module Liquid
      inputhash = {}
      # x parameters are in string form which must be split into a hash for easier parsing
      for i in x
-        inputhash.merge!(Hash[*i.split(',')])
+        inputhash.merge!(Hash[*(i.split(",").map(&:strip))])
      end
 
      #the corresponding variables in the expr are replaced with its respective value from the hashed parameters
@@ -460,7 +460,6 @@ module Liquid
 
       counter = counter + 1
      end
-
      #any variables that have not be replaced are assumed to be the input and replaced with the respective value
      if /[a-zA-Z]*/.match(expr)
       if input.class == String

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -437,6 +437,43 @@ module Liquid
       input.map{ |c| c.to_s(16) }
     end
 
+    def lambda_expr(input, x, expr)
+      inputlist = x.scan(/(?:\[.*?\]|[^,])+/)
+      inputhash = {}
+      for element in inputlist
+        newinput = element.tr('[]','').split(',')
+        inputhash[newinput[0]] = newinput[1]
+      end
+    
+      counter = 0
+      while(counter != inputhash.size())
+        if(expr.include? inputhash.keys[counter].tr(':',''))
+          isnum = /^\d+$/.match(inputhash.values[counter])
+          if(isnum.to_s.length == inputhash.values[counter].length)
+            expr = expr.gsub(expr[inputhash.keys[counter].tr(':','')], inputhash.values[counter].to_s)
+          else
+            rep = inputhash.values[counter]
+            expr = expr.gsub(expr[inputhash.keys[counter].tr(':','')], %('#{rep}') )
+          end
+        end
+        counter = counter + 1
+    
+      end
+        
+      if /[a-zA-Z]*/.match(expr)
+        if input.class == String
+          expr = expr.gsub(expr[/[a-zA-Z]+/], %("#{input}"))
+        elsif input.class == Array
+          input = "[#{input.join(",")}]"
+          expr = expr.gsub(/[a-zA-Z]+/,  %(#{input}))
+        else
+          expr = expr.gsub(/[a-zA-Z]+/,  %(#{input}))
+        end
+      end
+    
+      eval(expr)
+    end
+
     private
 
     def raise_property_error(property)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -437,41 +437,47 @@ module Liquid
       input.map{ |c| c.to_s(16) }
     end
 
-    def lambda_expr(input, x, expr)
-      inputlist = x.scan(/(?:\[.*?\]|[^,])+/)
-      inputhash = {}
-      for element in inputlist
-        newinput = element.tr('[]','').split(',')
-        inputhash[newinput[0]] = newinput[1]
-      end
-    
-      counter = 0
-      while(counter != inputhash.size())
-        if(expr.include? inputhash.keys[counter])
-          isnum = /^\d+$/.match(inputhash.values[counter])
-          if(isnum.to_s.length == inputhash.values[counter].length)
-            expr = expr.gsub(expr[inputhash.keys[counter]], inputhash.values[counter].to_s)
-          else
-            rep = inputhash.values[counter]
-            expr = expr.gsub(expr[inputhash.keys[counter]], %('#{rep}') )
-          end
-        end
-        counter = counter + 1
-    
-      end
-        
-      if /[a-zA-Z]*/.match(expr)
-        if input.class == String
-          expr = expr.gsub(expr[/[a-zA-Z]+/], %("#{input}"))
-        elsif input.class == Array
-          input = "[#{input.join(",")}]"
-          expr = expr.gsub(/[a-zA-Z]+/,  %(#{input}))
+    def lambda_expr(input, *x, expr)
+      #*x is an array that contains an arbitrary number of parameters 
+     inputhash = {}
+     # x parameters are in string form which must be split into a hash for easier parsing
+     for i in x
+        inputhash.merge!(Hash[*i.split(',')])
+     end
+
+     #the corresponding variables in the expr are replaced with its respective value from the hashed parameters
+     counter = 0
+     while(counter != inputhash.size())
+      if(expr.include? inputhash.keys[counter])
+        isnum = /^\d+$/.match(inputhash.values[counter])
+        if(isnum.to_s.length == inputhash.values[counter].length)
+          expr = expr.gsub(expr[inputhash.keys[counter]], inputhash.values[counter].to_s)
         else
-          expr = expr.gsub(/[a-zA-Z]+/,  %(#{input}))
-        end
+          rep = inputhash.values[counter]
+          expr = expr.gsub(expr[inputhash.keys[counter]], %('#{rep}') )
+        end 
       end
-    
-      eval(expr)
+
+      counter = counter + 1
+     end
+
+     #any variables that have not be replaced are assumed to be the input and replaced with the respective value
+     if /[a-zA-Z]*/.match(expr)
+      if input.class == String
+        expr = expr.gsub(expr[/[a-zA-Z]+/], %("#{input}"))
+      elsif input.class == Array
+        input = "[#{input.join(",")}]"
+        expr = expr.gsub(/[a-zA-Z]+/,  %(#{input}))
+      else
+        expr = expr.gsub(/[a-zA-Z]+/,  %(#{input}))
+      end 
+     end 
+
+     puts "Evaluate " + expr
+
+    #finally,the expression is evaluated 
+     eval(expr)     
+     
     end
 
     private

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -692,9 +692,9 @@ class StandardFiltersTest < Minitest::Test
   end
 
   def test_lambda_expr
-    assert_equal 2, @filters.lambda_expr([1,2,3,4,5], '[:x,1]', "y[x]")
-    assert_equal ["Str", "ing"], @filters.lambda_expr("Str-ing",'[y,-]', "str.split(y)")
-    assert_equal 6, @filters.lambda_expr([1,2,3,4,5], '[:xy,1],[:kb,2]', 'yx[xy]*yx[kb]')
+    assert_equal 2, @filters.lambda_expr([1,2,3,4,5], 'x, 1', "y[x]")
+    assert_equal 3, @filters.lambda_expr("Str-ing",'y, -', "str.index(y)")
+    assert_equal 6, @filters.lambda_expr([1,2,3,4,5], 'one, 1', 'two,2', 'input[one]*input[two]')
   end
 
   def test_cannot_access_private_methods

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -691,6 +691,12 @@ class StandardFiltersTest < Minitest::Test
     assert_equal ["54", "65", "73", "74", "69", "6e", "67"], @filters.to_hex([84, 101, 115, 116, 105, 110, 103])
   end
 
+  def test_lambda_expr
+    assert_equal 2, @filters.lambda_expr([1,2,3,4,5], '[:x,1]', "y[x]")
+    assert_equal ["Str", "ing"], @filters.lambda_expr("Str-ing",'[y,-]', "str.split(y)")
+    assert_equal 6, @filters.lambda_expr([1,2,3,4,5], '[:xy,1],[:kb,2]', 'yx[xy]*yx[kb]')
+  end
+
   def test_cannot_access_private_methods
     assert_template_result('a', "{{ 'a' | to_number }}")
   end


### PR DESCRIPTION
Created a filter `lambda_expr` to use lambda expression in Liquid.
This addresses the issue: https://github.com/Shopify/liquid/issues/886

The base of this was done by @AaskaS but unfortunately I needed to overwrite her commits as it was attempting to replace the entire file (I wonder if its something with how whitespace is treated).

The `lambda_expr` filter takes two arguments, a string with comma separated values for the expression parameters and a string for the expression. The filter is applied to a string, array, number or Liquid object which is used in the expression as the variable that does not have an associated parameter.

The argument for the expression parameter is a string of comma separated values, which are square brackets with a comma separated pair. The first item in the pair is the variable name and the second is the value.

To test:
- in the liquid directory run irb -I lib
- `require 'Liquid'`
- `Liquid::Template.parse("{% assign words = '1,2,3,4,5' | split: ',' %} {{ words | lambda_expr: '[xy,1],[kb,2]', 'yx[xy]*yx[kb]' }}").render`
- `Liquid::Template.parse("{{ 'Str-ing' | lambda_expr: '[xy,-]', 'thing.split(xy)' }}").render`
- `Liquid::Template.parse("{{ 5 | lambda_expr: '[xy,2]', 'xy*z' }}").render`
- `Liquid::Template.parse("{{ 'Str-ing' | lambda_expr: '[xy,-]', 'thing.index(xy)' }}").render`

Potential improvements:
- [x] Change the expression parameters argument to instead handle a dynamic number of arguments (i.e. *x) so that we can have multiple string pairs as the expression parameters. This removes the need for square brackets and is much more readable
- [ ] Improve variable names and include documentation

