### PR TITLE
to_hex filter for different input types

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -438,9 +438,12 @@ module Liquid
         input.to_i.to_s(16)
       elsif input.class == Array 
         if input.all? { |x| x.is_a? String } 
-          input = input.map{ |c| c.to_i }
+          input = input.map{ |c| c.to_i.to_s(16) }
+        else
+          input = input.map{ |c| c.to_s(16) }
         end
-        input.map{ |c| c.to_s(16) }
+      else
+        input.to_s(16)
       end
     end
 

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -434,7 +434,14 @@ module Liquid
 
     #Convert to hexadecimal
     def to_hex(input)
-      input.map{ |c| c.to_s(16) }
+       if input.class == String
+        input.to_i.to_s(16)
+      elsif input.class == Array 
+        if input.all? { |x| x.is_a? String } 
+          input = input.map{ |c| c.to_i }
+        end
+        input.map{ |c| c.to_s(16) }
+      end
     end
 
     def lambda_expr(input, *x, expr)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -689,6 +689,9 @@ class StandardFiltersTest < Minitest::Test
 
   def test_to_hex
     assert_equal ["54", "65", "73", "74", "69", "6e", "67"], @filters.to_hex([84, 101, 115, 116, 105, 110, 103])
+    assert_equal "a", @filters.to_hex(10)
+    assert_equal "a", @filters.to_hex('10')
+    assert_equal ["54", "65", "73", "74", "69", "6e", "67"], @filters.to_hex(["84", "101", "115", "116", "105", "110", "103"])
   end
 
   def test_lambda_expr


### PR DESCRIPTION
The `to_hex` filter now works for different input types:
- string containing an integer
- an integer
- an array of strings that are integers\
- an array of integers