### PR TITLE
Better loop and variable names

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -437,29 +437,26 @@ module Liquid
       input.map{ |c| c.to_s(16) }
     end
 
-    def lambda_expr(input, *x, expr)
-      #*x is an array that contains an arbitrary number of parameters 
-     inputhash = {}
-     # x parameters are in string form which must be split into a hash for easier parsing
-     for i in x
-        inputhash.merge!(Hash[*(i.split(",").map(&:strip))])
+    def lambda_expr(input, *variables, expr)
+     #*variables is an array that contains an arbitrary number of parameters 
+     vars = {}
+     # variables parameters are in string form which must be split into a hash for easier parsing
+     for i in variables
+        vars.merge!(Hash[*(i.split(",").map(&:strip))])
      end
 
      #the corresponding variables in the expr are replaced with its respective value from the hashed parameters
-     counter = 0
-     while(counter != inputhash.size())
-      if(expr.include? inputhash.keys[counter])
-        isnum = /^\d+$/.match(inputhash.values[counter])
-        if(isnum.to_s.length == inputhash.values[counter].length)
-          expr = expr.gsub(expr[inputhash.keys[counter]], inputhash.values[counter].to_s)
+     vars.each do |variable, value|
+      if(expr.include? variable)
+        isnum = /^\d+$/.match(value)
+        if(isnum.to_s.length == value.length)
+          expr = expr.gsub(expr[variable], value.to_s)
         else
-          rep = inputhash.values[counter]
-          expr = expr.gsub(expr[inputhash.keys[counter]], %('#{rep}') )
+          expr = expr.gsub(expr[variable], %('#{value}') )
         end 
       end
-
-      counter = counter + 1
      end
+
      #any variables that have not be replaced are assumed to be the input and replaced with the respective value
      if /[a-zA-Z]*/.match(expr)
       if input.class == String
@@ -472,11 +469,8 @@ module Liquid
       end 
      end 
 
-     puts "Evaluate " + expr
-
     #finally,the expression is evaluated 
-     eval(expr)     
-     
+     eval(expr)
     end
 
     private


### PR DESCRIPTION
Improved the loop so that that instead of using a while with a counter, it just iterates over the hash, giving the key and value as `variable` and `value` respectively.
Improved the names of some of the variables so that it is easier to understand.
Removed the print statement.